### PR TITLE
fix(security): upgrade axios to ^1.16.1 (CVE-2026-44496)

### DIFF
--- a/projects/DML-frontend/package.json
+++ b/projects/DML-frontend/package.json
@@ -44,7 +44,7 @@
     "@perawallet/connect": "^1.4.1",
     "@txnlab/use-wallet-react": "^4.0.0",
     "algosdk": "^3.0.0",
-    "axios": "^1.13.5",
+    "axios": "^1.16.1",
     "daisyui": "^4.0.0",
     "lute-connect": "^1.4.1",
     "notistack": "^3.0.1",


### PR DESCRIPTION
## Summary

- Upgrades `axios` from `^1.13.5` to `^1.16.1` in `projects/DML-frontend/package.json`

## Security Advisory

**CVE-2026-44496** — Axios: Regular Expression Denial of Service (ReDoS) via Cookie Name Injection (High severity)

A specially crafted cookie name triggers catastrophic backtracking in axios's cookie-parsing regex, which can block the JavaScript event loop and cause a denial-of-service condition in any app that processes untrusted HTTP responses.

## Fix

Bump `axios` to `^1.16.1` (current latest stable), which contains the patched cookie-name regex.

## After merging

Run `npm install` to regenerate `package-lock.json` with the patched version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)